### PR TITLE
Lib.hs

### DIFF
--- a/hs/src/Lib.hs
+++ b/hs/src/Lib.hs
@@ -1,37 +1,39 @@
+{-# LANGUAGE BangPatterns #-}
 module Lib (integrate, integrate_nosort)
     where
     import Data.List
 
-    data Point a=Point a a deriving Show -- x f
+    data Point a=Point !a !a deriving Show -- x f
 
     midpoint::(Fractional a)=>(a->a)->(Point a)->(Point a)->(Point a)
     midpoint func (Point x1 f1) (Point x2 f2)=Point xm fm
         where 
-            xm=(x1+x2)/(fromInteger 2)
+            xm=(x1+x2)/2
             fm=func xm
 
     area::(Fractional a)=>(Point a)->(Point a)->a
-    area (Point x1 f1) (Point x2 f2)=(f1+f2)*(x2-x1)/(fromInteger 2)
+    area (Point x1 f1) (Point x2 f2)=(f1+f2)*(x2-x1)/2
     
 
     integrate_iter::(Fractional a, Ord a)=>(a->a)->a->[Point a]->[a]->([Point a], [a])
-    integrate_iter func eps (left@(Point x1 f1):right@(Point x2 f2):others) areas
-                | abs (f1+f2-fm*(fromInteger 2)) <= eps = integrate_iter func eps (right:others) ((area left right):areas)
+    integrate_iter func eps (left@(Point x1 f1):right@(Point x2 f2):others) !areas
+                | abs (f1+f2-fm*2) <= eps = integrate_iter func eps (right:others) ((area left right):areas)
                 | otherwise = integrate_iter func eps (left:(Point xm fm):right:others) areas
                 where (Point xm fm)=midpoint func left right
     integrate_iter _ _ points areas = (points, areas)
         
     integrate::(Fractional a, Ord a)=>(a->a)->[a]->a->a
-    integrate func ticks eps=foldr (+) (fromInteger 0) sorted_areas
+    integrate func ticks eps = sum sorted_areas
             where 
                 points=fmap (\x->Point x $ func x) ticks
-                eps1=eps*(fromInteger 4)/((last ticks)-(head ticks))
+                eps1=eps*4/((last ticks)-(head ticks))
                 areas=snd $ integrate_iter func eps1 points []
                 sorted_areas=sortBy (\a b->compare (abs a) (abs b)) areas
+    {-# SPECIALIZE integrate :: (Double -> Double) -> [Double] -> Double -> Double #-}
 
     integrate_iter_nosort::(Fractional a, Ord a)=>(a->a)->a->[Point a]->a->([Point a], a)
-    integrate_iter_nosort func eps (left@(Point x1 f1):right@(Point x2 f2):others) old_area
-                | abs (f1+f2-fm*(fromInteger 2)) <= eps = integrate_iter_nosort func eps (right:others) ((area left right)+old_area)
+    integrate_iter_nosort func eps (left@(Point x1 f1):right@(Point x2 f2):others) !old_area
+                | abs (f1+f2-fm*2) <= eps = integrate_iter_nosort func eps (right:others) ((area left right)+old_area)
                 | otherwise = integrate_iter_nosort func eps (left:(Point xm fm):right:others) old_area
                 where (Point xm fm)=midpoint func left right
     integrate_iter_nosort _ _ points old_area = (points, old_area)
@@ -40,7 +42,6 @@ module Lib (integrate, integrate_nosort)
     integrate_nosort func ticks eps=sum_area
             where 
                 points=fmap (\x->Point x $ func x) ticks
-                eps1=eps*(fromInteger 4)/((last ticks)-(head ticks))
-                sum_area=snd $ integrate_iter_nosort func eps1 points $ fromInteger 0
-                
-            
+                eps1=eps*4/((last ticks)-(head ticks))
+                sum_area=snd $ integrate_iter_nosort func eps1 points 0
+    {-# SPECIALIZE integrate_nosort :: (Double -> Double) -> [Double] -> Double -> Double #-}


### PR DESCRIPTION
- Add strict annotations to data Point.
- Specialize functions integrate and integrate_nosort to Double, which greatly improves performance.
- add bang patterns to old_area and areas in the functions integrate_nosort and integrate
- remove superfluous "fromInteger", could really change /2 to *0.5, but there is no performance gain.