### PR TITLE
Add python numba version

### DIFF
--- a/py-numba/adapt.py
+++ b/py-numba/adapt.py
@@ -1,0 +1,55 @@
+import collections
+
+import numba as nb
+import numpy as np
+
+
+Point = collections.namedtuple('Point', 'x y')
+
+
+@nb.jit(nopython=True)
+def sum_list(x):
+    s = 0.0
+    for k in range(len(x)):
+        s += x[k]
+
+    return s
+
+
+@nb.jit(nopython=True)
+def integrate_iter(func, eps, points, nosort):
+    areas = []
+    if len(points) < 2:
+        return 0.0
+
+    right = points[-1]
+    sz = len(points)
+
+    while sz > 1:
+        left = points[-2]
+        xm = 0.5 * (left.x + right.x)
+        fm = func(xm)
+        if abs(left.y + right.y - 2.0 * fm) <= eps:
+            area = (left.y + right.y + fm * 2.0) * (right.x - left.x) * 0.25
+            areas.append(area)
+            points.pop()
+            right = left
+            sz -= 1
+        else:
+            points[-1] = Point(xm, fm)
+            points.append(right)
+            sz += 1
+
+    if not nosort:
+        areas_arr = np.array(areas)
+        areas_arr = np.sort(areas_arr)
+        return np.sum(areas_arr)
+    else:
+        return sum_list(areas)
+
+
+@nb.jit(nopython=True)
+def integrate(func, ticks, eps, nosort=False):
+    eps1 = eps * 4.0 / (ticks[-1] - ticks[0])
+    points = [Point(x, func(x))for x in ticks]
+    return integrate_iter(func, eps1, points, nosort)

--- a/py-numba/main.py
+++ b/py-numba/main.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+import timeit
+import math
+
+import numba as nb
+
+import adapt
+
+
+@nb.jit(nopython=True)
+def foo(x):
+    return math.sin(x * x)
+
+#for i in range(0,100):
+#    print(integrate(lambda x:math.sin(x**2), [0.0,1.0, 2.0, math.sqrt(8*math.pi)],1e-10))
+    #print(integrate(lambda x: x ** 2, [0.0, 1.0], 1e-10))
+
+
+print("Validating precision:")
+TOL = 1e-10
+PRECISE_RESULT = 0.527038339761566009286263102166809763899326865179511011538
+
+print('integrate:')
+result = adapt.integrate(foo, [0.0, 1.0, 2.0, math.sqrt(8 * math.pi)], TOL, False)
+diff = abs(PRECISE_RESULT - result)
+print("diff={0}".format(diff))
+print("Required precision={0}".format(TOL))
+
+print('integrate nosort:')
+result = adapt.integrate(foo, [0.0, 1.0, 2.0, math.sqrt(8 * math.pi)], TOL, True)
+diff = abs(PRECISE_RESULT - result)
+print("diff={0}".format(diff))
+print("Required precision={0}".format(TOL))
+
+n = 10
+
+print('integrate:')
+timer = timeit.Timer('integrate(foo, [0.0,1.0, 2.0, math.sqrt(8*math.pi)], 1e-10, False)', setup="from __main__ import foo; import math; from adapt import integrate;")
+
+# Run twice, skipping the first which includes the jit cost
+dt = timer.repeat(repeat=2, number=n)[-1]
+print("dt={0} ms".format(dt / n * 1000))
+
+print('integrate nosort:')
+timer = timeit.Timer('integrate(foo, [0.0,1.0, 2.0, math.sqrt(8*math.pi)], 1e-10, True)', setup="from __main__ import foo; import math; from adapt import integrate;")
+
+# Run twice, skipping the first which includes the jit cost
+dt = timer.repeat(repeat=2, number=n)[-1]
+print("dt={0} ms".format(dt / n * 1000))


### PR DESCRIPTION
I added a [numba](http://numba.pydata.org/) version of the python benchmark since it was trivial to adapt and is one of the primary tools for writing fast scientific code for python. The outputs on my machine (2015 Apple Macbook Pro):

```
Validating precision:
integrate:
diff=6.222800053024002e-13
Required precision=1e-10

integrate nosort:
diff=3.6337599595981374e-13
Required precision=1e-10

integrate:
dt=228.40172430005623 ms

integrate nosort:
dt=132.03206120015238 ms
```

For comparison, the python benchmark on my machine took  2773 ms and the Julia generic version took 237 ms w/sorting and 91 ms without sorting. 

So with a few small changes to the python version (which still may not be optimal), you can get performance in the neighborhood of Julia. 